### PR TITLE
Disable iroha in runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,20 +125,6 @@ name = "alt_serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03beeddedd09889b96def26f78ba46e34ffd9bdaaa33b2c980cbaa1d0e762686"
-dependencies = [
- "alt_serde_derive",
-]
-
-[[package]]
-name = "alt_serde_derive"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6757ed5faa82ccfbfa1837cd7a7a2e1bdb634236f21fa74d6c5c5736152838a1"
-dependencies = [
- "proc-macro2 1.0.19",
- "quote 1.0.7",
- "syn 1.0.38",
-]
 
 [[package]]
 name = "ansi_term"
@@ -2399,29 +2385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
-name = "iroha-bridge"
-version = "2.0.0-rc5"
-dependencies = [
- "alt_serde",
- "async-std",
- "frame-support",
- "frame-system",
- "iroha_client_no_std",
- "log 0.4.11",
- "pallet-balances",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "serde",
- "serde_json 1.0.44",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "tempfile",
- "treasury",
-]
-
-[[package]]
 name = "iroha_client_no_std"
 version = "0.1.0"
 source = "git+https://github.com/EmelianPiker/iroha?branch=substrate-bridge-rococo#d6097b81572554444b2e9a9a560c581006fc895a"
@@ -2429,7 +2392,6 @@ dependencies = [
  "async-std",
  "chrono",
  "parity-scale-codec",
- "serde",
  "serde_json 1.0.44",
 ]
 
@@ -4254,7 +4216,6 @@ dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
- "iroha-bridge",
  "pallet-balances",
  "pallet-randomness-collective-flip",
  "pallet-sudo",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -8,7 +8,7 @@ use cumulus_primitives::ParaId;
 use parachain_runtime::{
 	AccountId, BalancesConfig, GenesisConfig, Signature, SudoConfig, SystemConfig,
 	ParachainInfoConfig, WASM_BINARY,
-	IrohaBridgeConfig,
+	//IrohaBridgeConfig,
 	KSMConfig, XORConfig, DOTConfig,
 };
 
@@ -82,10 +82,12 @@ pub fn get_chain_spec(id: ParaId) -> ChainSpec {
 						67, 8, 115, 247, 189, 204, 26, 181, 226, 232, 81, 123, 12, 81, 120,
 					]),
 				],
+                /*
 				vec![iroha_crypto::PublicKey::try_from(vec![
 					52u8, 45, 84, 67, 137, 84, 47, 252, 35, 59, 237, 44, 144, 70, 71, 206, 243, 67,
 					8, 115, 247, 189, 204, 26, 181, 226, 232, 81, 123, 12, 81, 120,
 				]).unwrap()],
+                */
 				id,
 			)
 		},
@@ -109,10 +111,12 @@ pub fn staging_test_net(id: ParaId) -> ChainSpec {
 			testnet_genesis(
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
+                /*
 				vec![iroha_crypto::PublicKey::try_from(vec![
 					52u8, 45, 84, 67, 137, 84, 47, 252, 35, 59, 237, 44, 144, 70, 71, 206, 243, 67,
 					8, 115, 247, 189, 204, 26, 181, 226, 232, 81, 123, 12, 81, 120,
 				]).unwrap()],
+                */
 				id,
 			)
 		},
@@ -130,7 +134,7 @@ pub fn staging_test_net(id: ParaId) -> ChainSpec {
 fn testnet_genesis(
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
-	iroha_peers: Vec<iroha_crypto::PublicKey>,
+	//iroha_peers: Vec<iroha_crypto::PublicKey>,
 	id: ParaId,
 ) -> GenesisConfig {
 	GenesisConfig {
@@ -176,6 +180,6 @@ fn testnet_genesis(
 				.map(|k| (k, 1 << 60))
 				.collect(),
 		}),
-		iroha_bridge: Some(IrohaBridgeConfig { authorities: endowed_accounts.clone(), iroha_peers }),
+		//iroha_bridge: Some(IrohaBridgeConfig { authorities: endowed_accounts.clone(), iroha_peers }),
 	}
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -60,6 +60,7 @@ pub fn new_partial(
 		crate::service::Executor,
 	>(&config)?;
 
+    /*
     let dev_seed = config.dev_key_seed.clone();
 
     println!("Prepare for adding bridge keys to keystore");
@@ -81,6 +82,7 @@ pub fn new_partial(
             )
             .expect("Dev Seed should always succeed.");
     }
+    */
 
 	let client = Arc::new(client);
 	//let select_chain = sc_consensus::LongestChain::new(backend.clone());

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -43,7 +43,7 @@ cumulus-primitives = { git = "https://github.com/paritytech/cumulus",  default-f
 
 # Additional dependencies
 treasury = { path = "../pallets/treasury", default-features = false }
-iroha-bridge = { path = "../pallets/iroha-bridge", default-features = false }
+#iroha-bridge = { path = "../pallets/iroha-bridge", default-features = false }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.6" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,8 +47,10 @@ pub use template;
 /// Import the message pallet.
 pub use cumulus_token_dealer;
 
+/*
 /// Importing a iroha-bridge pallet
 pub use iroha_bridge;
+*/
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -101,8 +103,8 @@ pub mod opaque {
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("substrate-iroha-bridge"),
-	impl_name: create_runtime_str!("substrate-iroha-bridge"),
+	spec_name: create_runtime_str!("substrate-pswap"),
+	impl_name: create_runtime_str!("substrate-pswap"),
 	authoring_version: 1,
 	spec_version: 1,
 	impl_version: 1,
@@ -403,6 +405,7 @@ parameter_types! {
     pub const UnsignedPriority: u64 = 100;
 }
 
+/*
 /// Used for the module template in `./template.rs`
 impl iroha_bridge::Trait for Runtime {
     type AuthorityId = iroha_bridge::crypto::TestAuthId;
@@ -411,6 +414,7 @@ impl iroha_bridge::Trait for Runtime {
     type Event = Event;
     type UnsignedPriority = UnsignedPriority;
 }
+*/
 
 construct_runtime! {
 	pub enum Runtime where
@@ -434,7 +438,7 @@ construct_runtime! {
 		DOT: pallet_balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
 		KSM: pallet_balances::<Instance3>::{Module, Call, Storage, Config<T>, Event<T>},
 		Treasury: treasury::{Module, Call, Storage, Event<T>},
-		IrohaBridge: iroha_bridge::{Module, Call, Storage, Config<T>, Event<T>},
+		//IrohaBridge: iroha_bridge::{Module, Call, Storage, Config<T>, Event<T>},
 	}
 }
 


### PR DESCRIPTION
Reason: Speed up of compilation required
Solution: Comment iroha

1. Comment iroha in runtime/Cargo.toml
2. Comment iroha in runtime/src/lib.rs
3. Comment iroha in node service.rs and chain_spec.rs